### PR TITLE
Add missing run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x.x') }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b111c15fdc8c029989330ff559184198c161100a59312f5dc19ddeb9b5a15889
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x.x') }}
 


### PR DESCRIPTION
soxr is a shared library, so if a package host-depends on soxr to build a library, this library will need to have soxr installed to run. This is dealt automatically by adding `run_exports`, see:
* https://conda-forge.org/docs/maintainer/pinning_deps.html#specifying-run-exports
* https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#export-runtime-requirements

For soxr I do not know in detail the ABI compatibility policy, but given that:
* It is seldom released
* In the NEWS https://sourceforge.net/p/soxr/code/ci/master/tree/NEWS they mention possible ABI changes in the future
* The still have 0 major version

I think it make sense to assume that we could have ABI incompatibility for new patch releases.